### PR TITLE
Fixed lqt slot acceptor issues

### DIFF
--- a/generator/classes.lua
+++ b/generator/classes.lua
@@ -1053,29 +1053,29 @@ private:
 #include <QDebug>
 
 const QMetaObject *lqt_shell_]]..n..[[::metaObject() const {
-  if (!lqtL_isMainThread()) {
-    printf("Warning: call ]]..c.xarg.fullname..[[::metaObject() from thread!\n");
-    return &]]..c.xarg.fullname..[[::staticMetaObject;
-  }
+        if (!lqtL_isMainThread()) {
+          printf("Warning: call ]]..c.xarg.fullname..[[::metaObject() from thread!\n");
+          return &]]..c.xarg.fullname..[[::staticMetaObject;
+        }
 
-  const QMetaObject& meta = lqtL_qt_metaobject(L
-    , "]]..c.xarg.fullname..[[*"
-    , this
-    , ]]..c.xarg.fullname..[[::staticMetaObject
-  );
-  return &meta;
+        const QMetaObject& meta = lqtL_qt_metaobject(L
+            , "]]..c.xarg.fullname..[[*"
+            , this
+            , ]]..c.xarg.fullname..[[::staticMetaObject
+        );
+        return &meta;
 }
 
 int lqt_shell_]]..n..[[::qt_metacall(QMetaObject::Call call, int index, void **args) {
-  //qDebug() << "fake calling!";
-  index = ]]..c.xarg.fullname..[[::qt_metacall(call, index, args);
-  if (!lqtL_isMainThread()) {
-    printf("Warning: call ]]..c.xarg.fullname..[[::qt_metacall() from thread!\n");
-    return index;
-  }
-  if (index < 0)
-    return index;
-  return lqtL_qt_metacall(L, this, lqtSlotAcceptor_]]..module_name..[[, call, "]]..c.xarg.fullname..[[*", index, args);
+        //qDebug() << "fake calling!";
+        index = ]]..c.xarg.fullname..[[::qt_metacall(call, index, args);
+        if (!lqtL_isMainThread()) {
+          printf("Warning: call ]]..c.xarg.fullname..[[::qt_metacall() from thread!\n");
+          return index;
+        }
+        if (index < 0)
+          return index;
+        return lqtL_qt_metacall(L, this, lqtSlotAcceptor_]]..module_name..[[[L].get(), call, "]]..c.xarg.fullname..[[*", index, args);
 }
 ]])
 	end
@@ -1270,7 +1270,7 @@ end
 		print_meta("\tlqtL_qvariant_custom_qtgui(L);")
 	end
 	print_meta('\tlqtL_register_super(L);')
-	print_meta('\tlqtSlotAcceptor_'..module_name..' = new LqtSlotAcceptor(L);')
+	print_meta('\tlqtSlotAcceptor_'..module_name..'[L] = std::unique_ptr<LqtSlotAcceptor>(new LqtSlotAcceptor(L));')
 	print_meta('\tlua_settop(L, top);')
 	print_meta('\treturn 1;\n}')
 	if fmeta then fmeta:close() end

--- a/generator/signalslot.lua
+++ b/generator/signalslot.lua
@@ -62,15 +62,17 @@ function print_slots(s)
 	print_slot_h'  lua_State *L;'
 	print_slot_h'  public:'
 	print_slot_h('  LqtSlotAcceptor(lua_State *l, QObject *p=NULL) : QObject(p), L(l) { setObjectName("'..module_name..'"); lqtL_register(L, this, NULL); }')
-	print_slot_h'  virtual ~LqtSlotAcceptor() { lqtL_unregister(L, this, NULL); }'
+	print_slot_h'  virtual ~LqtSlotAcceptor() { /*lqtL_unregister(L, this, NULL);*/ }'
 	print_slot_h'  public slots:'
 	for p, b in pairs(s) do
 		print_slot_h('  '..p..';')
 		print_slot_c(b)
 	end
 	print_slot_h'};\n'
-	print_slot_h('\nextern LqtSlotAcceptor *lqtSlotAcceptor_'..module_name..';')
-	print_slot_c('\nLqtSlotAcceptor *lqtSlotAcceptor_'..module_name..';')
+	print_slot_h('\n#include <map>')
+	print_slot_h('\n#include <memory>')
+	print_slot_h('\nextern std::map<lua_State*,std::unique_ptr<LqtSlotAcceptor>> lqtSlotAcceptor_'..module_name..';')
+	print_slot_c('\nstd::map<lua_State*,std::unique_ptr<LqtSlotAcceptor>> lqtSlotAcceptor_'..module_name..';')
 end
 
 


### PR DESCRIPTION
1. The dynamically created "LqtSlotAcceptor" objects were never deleted. Wrapped it into a unique_ptr to auto-delete them, when the library is unloaded.

2. When multiple lua_States loaded modules (via "require") from lqt5, the application at some point crashed. The Problem was, that only one global "LqtSlotAcceptor" object is used, which holds the latest lua_State, which loaded the lqt5 module. If then a Slot from a previous lua_State was triggered the global "LqtSlotAcceptor" object accessed the wrong lua_State. To solve this, i changed the global "LqtSlotAcceptor" pointer to a std::map indexed by the "lua_State*" holding an "LqtSlotAcceptor" object for each lua_State to make sure we don´t get such conflicts.

